### PR TITLE
Add application/wasm Content-Type mapping for .wasm files

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,7 @@ variable "file_types" {
     ".xhtml"  = "application/xhtml+xml"
     ".css"    = "text/css; charset=utf-8"
     ".js"     = "application/javascript"
+    ".wasm"   = "application/wasm"
     ".xml"    = "application/xml"
     ".json"   = "application/json"
     ".jsonld" = "application/ld+json"


### PR DESCRIPTION
Map `.wasm` files to `application/wasm` Content-Type instead of `application/octet-stream`

Source:
---
`application/wasm` is registered in [IANA](https://www.iana.org/): 
- https://www.iana.org/assignments/media-types/application/wasm
- https://www.iana.org/assignments/media-types/media-types.xhtml#application
