### PR TITLE
docs: fix sha512 digest key typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ the result of applying the named hash function to the file contents:
 * `sha1`
 * `sha256`
 * `base64sha256`
-* `base512`
+* `sha512`
 * `base64sha512`
 
 ## Template Files


### PR DESCRIPTION
## Summary
- Fixes the README digests list so it documents `sha512` instead of `base512`, matching the keys the module actually exposes.

Fixes #3

## Test plan
- [x] Confirm `files.tf` already uses `sha512` / `base64sha512`
- [x] Confirm README digest list matches those keys